### PR TITLE
Domain type system should be serialized

### DIFF
--- a/src/framework_ble/device.rs
+++ b/src/framework_ble/device.rs
@@ -1,7 +1,19 @@
+use serde::Serialize;
 use std::collections::HashMap;
-#[derive(Clone, Debug)]
+
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct Device {
     pub name: String,
+    #[serde(skip_serializing)]
     pub address: [u8; 6],
+    #[serde(skip_serializing)]
     pub states: HashMap<String, String>,
+}
+
+impl Device {
+    pub fn default_with_name(name: String) -> Self {
+        let mut device = Self::default();
+        device.name = name;
+        device
+    }
 }

--- a/src/routes/devices.rs
+++ b/src/routes/devices.rs
@@ -4,7 +4,7 @@ use actix_web::{web, Responder, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub struct Devices {
     pub devices: Vec<Device>,
 }
@@ -12,16 +12,6 @@ pub struct Devices {
 #[derive(Serialize)]
 struct DeviceStatesSerialize {
     states: HashMap<String, String>,
-}
-
-#[derive(Serialize)]
-struct DeviceSerialize {
-    name: String,
-}
-
-#[derive(Serialize)]
-struct DevicesSerialize {
-    devices: Vec<DeviceSerialize>,
 }
 
 #[derive(Deserialize)]
@@ -32,14 +22,12 @@ pub struct Info {
 pub async fn devices(data: web::Data<Devices>) -> Result<impl Responder> {
     let device_list_data = &data.devices;
 
-    let mut dev: Vec<DeviceSerialize> = Vec::new();
+    let mut dev: Vec<Device> = Vec::new();
     for d in device_list_data {
-        dev.push(DeviceSerialize {
-            name: d.name.clone(),
-        });
+        dev.push(Device::default_with_name(d.name.clone()));
     }
 
-    let devices_list_struct = DevicesSerialize { devices: dev };
+    let devices_list_struct = Devices { devices: dev };
 
     Ok(web::Json(devices_list_struct))
 }
@@ -59,9 +47,7 @@ pub async fn device(info: web::Path<Info>, data: web::Data<Devices>) -> Result<i
         },
     };
 
-    let device_serialized = DeviceSerialize {
-        name: device.name.clone(),
-    };
+    let device_serialized = Device::default_with_name(device.name.clone());
 
     Ok(web::Json(device_serialized))
 }


### PR DESCRIPTION
Les serializers sont derives des types que tu crees pour resoudre ton probleme, ils ne devraient pas etre differents pour ne pas evoluer independamment. Si tu ne veux pas tous les fields tu peux `skip`.